### PR TITLE
Fixie for Unit & Integration Tests

### DIFF
--- a/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
+++ b/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
+++ b/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
@@ -1,13 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>Ofx.Battleship.API.FixieTests</RootNamespace>
+    <AssemblyName>Ofx.Battleship.API.FixieTests</AssemblyName>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Fixie" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <DotNetCliToolReference Include="Fixie.Console" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ofx.Battleship.API\Battleship.API.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
+++ b/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
@@ -4,4 +4,10 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Fixie" Version="2.2.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <DotNetCliToolReference Include="Fixie.Console" Version="2.2.0" />
+  </ItemGroup>
+
 </Project>

--- a/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
+++ b/Battleship.API.FixieTests/Battleship.API.FixieTests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Fixie" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
     <DotNetCliToolReference Include="Fixie.Console" Version="2.2.0" />
   </ItemGroup>
 

--- a/Battleship.API.FixieTests/Common/BattleshipDbContextFactory.cs
+++ b/Battleship.API.FixieTests/Common/BattleshipDbContextFactory.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Ofx.Battleship.API.Data;
+using Ofx.Battleship.API.Entities;
+using System;
+
+namespace Ofx.Battleship.API.FixieTests.Common
+{
+    public class BattleshipDbContextFactory
+    {
+        public static BattleshipDbContext Create()
+        {
+            var options = new DbContextOptionsBuilder<BattleshipDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            var context = new BattleshipDbContext(options);
+
+            context.Database.EnsureCreated();
+
+            var game = new Game { GameId = 1 };
+            context.Games.Add(game);
+
+            var board = new Board { 
+                Game = game,
+                DimensionX = 10,
+                DimensionY = 10
+            };
+            context.Boards.Add(board);
+
+            var ship = new Ship { Board = board };
+            context.Ships.Add(ship);
+
+            context.ShipParts.AddRange(new[]
+            {
+                new ShipPart { Ship = ship, X = 1, Y = 1 },
+                new ShipPart { Ship = ship, X = 1, Y = 2 }
+            });
+
+            context.SaveChanges();
+
+            return context;
+        }
+
+        public static void Destroy(BattleshipDbContext context)
+        {
+            context.Database.EnsureDeleted();
+
+            context.Dispose();
+        }
+    }
+}

--- a/Battleship.API.FixieTests/Common/IntegrationTestWebApplicationFactory.cs
+++ b/Battleship.API.FixieTests/Common/IntegrationTestWebApplicationFactory.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Ofx.Battleship.API.Data;
+using Ofx.Battleship.API.Entities;
+using System;
+
+namespace Ofx.Battleship.API.FixieTests.Common
+{ 
+    public class IntegrationTestWebApplicationFactory<TStartup> : WebApplicationFactory<TStartup> where TStartup : class
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder
+                .ConfigureServices(services =>
+                {
+                    // Create a new service provider.
+                    var serviceProvider = new ServiceCollection()
+                        .AddEntityFrameworkInMemoryDatabase()
+                        .BuildServiceProvider();
+
+                    services.AddDbContext<BattleshipDbContext>(options =>
+                    {
+                        options.UseInMemoryDatabase(Guid.NewGuid().ToString());
+                        options.UseInternalServiceProvider(serviceProvider);
+                    });
+
+                    services.AddScoped<IBattleshipDbContext>(provider => provider.GetService<BattleshipDbContext>());
+
+                    var sp = services.BuildServiceProvider();
+
+                    using var scope = sp.CreateScope();
+                    var scopedServices = scope.ServiceProvider;
+                    
+                    var context = scopedServices.GetRequiredService<BattleshipDbContext>();
+                    context.Database.EnsureCreated();
+
+                    var game = new Game();
+                    context.Games.Add(game);
+
+                    var board = new Board
+                    {
+                        Game = game,
+                        DimensionX = 10,
+                        DimensionY = 10
+                    };
+                    context.Boards.Add(board);
+
+                    var ship = new Ship { Board = board };
+                    context.Ships.Add(ship);
+
+                    context.ShipParts.AddRange(new[]
+                    {
+                        new ShipPart { Ship = ship, X = 1, Y = 1 },
+                        new ShipPart { Ship = ship, X = 1, Y = 2 }
+                    });
+
+                    context.SaveChanges();
+                });
+        }
+    }
+}

--- a/Battleship.API.FixieTests/Common/TestBase.cs
+++ b/Battleship.API.FixieTests/Common/TestBase.cs
@@ -1,0 +1,20 @@
+﻿using Ofx.Battleship.API.Data;
+using System;
+
+namespace Ofx.Battleship.API.FixieTests.Common
+{
+    public class TestBase : IDisposable
+    {
+        protected readonly BattleshipDbContext _context;
+
+        public TestBase()
+        {
+            _context = BattleshipDbContextFactory.Create();
+        }
+
+        public void Dispose()
+        {
+            BattleshipDbContextFactory.Destroy(_context);
+        }
+    }
+}

--- a/Battleship.API.FixieTests/Common/TestBase.cs
+++ b/Battleship.API.FixieTests/Common/TestBase.cs
@@ -5,10 +5,12 @@ namespace Ofx.Battleship.API.FixieTests.Common
 {
     public class TestBase : IDisposable
     {
+        protected readonly IntegrationTestWebApplicationFactory<Startup> _factory;
         protected readonly BattleshipDbContext _context;
 
-        public TestBase()
+        public TestBase(IntegrationTestWebApplicationFactory<Startup> factory)
         {
+            _factory = factory;
             _context = BattleshipDbContextFactory.Create();
         }
 

--- a/Battleship.API.FixieTests/Common/Utilities.cs
+++ b/Battleship.API.FixieTests/Common/Utilities.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ofx.Battleship.API.FixieTests.Common
+{
+    public class Utilities
+    {
+        public static StringContent GetRequestContent(object obj)
+        {
+            return new StringContent(JsonConvert.SerializeObject(obj), Encoding.UTF8, "application/json");
+        }
+
+        public static async Task<T> GetResponseContent<T>(HttpResponseMessage response)
+        {
+            var stringResponse = await response.Content.ReadAsStringAsync();
+
+            return JsonConvert.DeserializeObject<T>(stringResponse);
+        }
+    }
+}

--- a/Battleship.API.FixieTests/Features/CreateGameTests.cs
+++ b/Battleship.API.FixieTests/Features/CreateGameTests.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using Ofx.Battleship.API.Features.Games;
+using Ofx.Battleship.API.FixieTests.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Battleship.API.FixieTests.Features
+{
+    public class CreateGameTests : TestBase
+    {
+        public async Task Handle_GivenValidRequest_ShouldReturnNewGameId()
+        {
+            // Arrange
+            var handler = new Create.Handler(_context);
+
+            // Act
+            var response = await handler.Handle(new Create.Command(), CancellationToken.None);
+
+            // Assert
+            response.Should().BePositive();
+        }
+    }
+}

--- a/Battleship.API.FixieTests/Features/CreateGameTests.cs
+++ b/Battleship.API.FixieTests/Features/CreateGameTests.cs
@@ -3,11 +3,15 @@ using Ofx.Battleship.API.Features.Games;
 using Ofx.Battleship.API.FixieTests.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using static Ofx.Battleship.API.FixieTests.Common.Utilities;
 
-namespace Battleship.API.FixieTests.Features
+namespace Ofx.Battleship.API.FixieTests.Features
 {
     public class CreateGameTests : TestBase
     {
+        public CreateGameTests(IntegrationTestWebApplicationFactory<Startup> factory) : base(factory)
+        { }
+
         public async Task Handle_GivenValidRequest_ShouldReturnNewGameId()
         {
             // Arrange
@@ -18,6 +22,22 @@ namespace Battleship.API.FixieTests.Features
 
             // Assert
             response.Should().BePositive();
+        }
+
+        public async Task CreateGame_ReturnsNewGameId()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.PostAsync("/api/games", null);
+
+            response.EnsureSuccessStatusCode();
+
+            var gameId = await GetResponseContent<int>(response);
+
+            // Assert
+            gameId.Should().BePositive();
         }
     }
 }

--- a/Ofx.Battleship.Slice.sln
+++ b/Ofx.Battleship.Slice.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Battleship.API.FixieTests", "Battleship.API.FixieTests\Battleship.API.FixieTests.csproj", "{D477A7AA-7A66-46B7-AE72-A5CC28D3EAD9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{DB8F23CA-DF47-43EF-957D-D79CC9E95331}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB8F23CA-DF47-43EF-957D-D79CC9E95331}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB8F23CA-DF47-43EF-957D-D79CC9E95331}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D477A7AA-7A66-46B7-AE72-A5CC28D3EAD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D477A7AA-7A66-46B7-AE72-A5CC28D3EAD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D477A7AA-7A66-46B7-AE72-A5CC28D3EAD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D477A7AA-7A66-46B7-AE72-A5CC28D3EAD9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Attempt at using Fixie for convention based testing. 

Notes:
- Simple case doesn't seem much different to xUnit.
- Attempting to add integration test using web app factory failed at runtime, as Fixie doesn't support DI out of the box. Some have manually added DI to their conventions, but this involved crafting the service collection again, which gets further away from how things run in production, and further away from the web app factory pattern.

First impression: Fixie does not add significant value over xUnit, and not having DI out of box is a fail.

References:
- https://jimmybogard.com/integration-testing-with-xunit/
- https://fixie.github.io/
- https://github.com/fixie/fixie/wiki