### PR TITLE
add config to support vs-online

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,9 @@
 {
+  "dockerFile": "../Dockerfile",
+  "forwardPorts": [
+    5000,
+    5001
+  ],
   "remoteEnv": {
     "PROJECT": "/home/vsonline/workspace/Ofx.Battleship.API/Battleship.API.csproj"
   }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.sh]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+
+[{*.yml,*.yaml}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace=true
+
+[*.sql]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace=true
+
+[*.json]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace=true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/Ofx.Battleship.API/bin/Debug/netcoreapp3.0/Ofx.Battleship.API.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/Ofx.Battleship.API",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "listening on port ([0-9]+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/Ofx.Battleship.API/Battleship.API.csproj",
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}


### PR DESCRIPTION
PR created from VS Code Online!

This adds the required devcontainer config to run in Azure.
Also adding the base dotfiles for VS Code debugging.

Have successfully run this and hit API from Postman. Cool.